### PR TITLE
cstring missing for Linux systems

### DIFF
--- a/VVGL/src/GLCPUToTexCopier.cpp
+++ b/VVGL/src/GLCPUToTexCopier.cpp
@@ -1,5 +1,5 @@
 #include "GLCPUToTexCopier.hpp"
-
+#include <cstring>
 
 
 

--- a/VVGL/src/GLScene.cpp
+++ b/VVGL/src/GLScene.cpp
@@ -1,5 +1,5 @@
 #include "GLScene.hpp"
-
+#include <cstring>
 
 
 

--- a/VVGL/src/GLTexToCPUCopier.cpp
+++ b/VVGL/src/GLTexToCPUCopier.cpp
@@ -1,5 +1,5 @@
 #include "GLTexToCPUCopier.hpp"
-
+#include <cstring>
 
 
 


### PR DESCRIPTION
Compiling on Linux with GNU g++, and on Windows with MingGW g++ these header files are missing.