### PR TITLE
Update the macOS SDK version

### DIFF
--- a/examples/apple/ISFSandbox.xcodeproj/project.pbxproj
+++ b/examples/apple/ISFSandbox.xcodeproj/project.pbxproj
@@ -5078,7 +5078,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
-				SDKROOT = macosx10.13;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -5129,7 +5129,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "";
-				SDKROOT = macosx10.13;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Updated the SDK version so that the build would pass on any latest environment.

FYI, I've been developing an ISF plug-in for After Effects. It'd inherit the essence of PixelBlender, which was a shader language for Adobe products but deprecated as of CS6.